### PR TITLE
Support toggling between adding/resolving a subscription 

### DIFF
--- a/Sources/Graphiti/API/API.swift
+++ b/Sources/Graphiti/API/API.swift
@@ -14,7 +14,8 @@ extension API {
         context: ContextType,
         on eventLoopGroup: EventLoopGroup,
         variables: [String: Map] = [:],
-        operationName: String? = nil
+        operationName: String? = nil,
+        addingSubscription: Bool = false
     ) -> EventLoopFuture<GraphQLResult> {
         return schema.execute(
             request: request,
@@ -22,7 +23,8 @@ extension API {
             context: context,
             eventLoopGroup: eventLoopGroup,
             variables: variables,
-            operationName: operationName
+            operationName: operationName,
+            addingSubscription: addingSubscription
         )
     }
 }

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -44,6 +44,7 @@ public extension Schema {
     ) -> EventLoopFuture<GraphQLResult> {
         do {
             return try graphql(
+                subscriptionStrategy: AddSubscriptionFieldExecutionStrategy(),
                 schema: schema,
                 request: request,
                 rootValue: resolver,

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -40,11 +40,12 @@ public extension Schema {
         context: Context,
         eventLoopGroup: EventLoopGroup,
         variables: [String: Map] = [:],
-        operationName: String? = nil
+        operationName: String? = nil,
+        addingSubscription: Bool = false
     ) -> EventLoopFuture<GraphQLResult> {
         do {
             return try graphql(
-                subscriptionStrategy: AddSubscriptionFieldExecutionStrategy(),
+                subscriptionStrategy: addingSubscription ? AddSubscriptionFieldExecutionStrategy() : SerialFieldExecutionStrategy(),
                 schema: schema,
                 request: request,
                 rootValue: resolver,

--- a/Sources/Graphiti/Subscription/AddSubscriptionFieldExecutionStrategy.swift
+++ b/Sources/Graphiti/Subscription/AddSubscriptionFieldExecutionStrategy.swift
@@ -1,0 +1,56 @@
+//
+//  File.swift
+//  
+//
+//  Created by Ahmed Farrakha on 12/4/20.
+//
+
+import Foundation
+import GraphQL
+import NIO
+
+struct AddSubscriptionFieldExecutionStrategy: SubscriptionFieldExecutionStrategy {
+    
+    public init () {}
+
+    public func executeFields(
+        exeContext: ExecutionContext,
+        parentType: GraphQLObjectType,
+        sourceValue: Any,
+        path: GraphQL.IndexPath,
+        fields: [String: [GraphQL.Field]]
+    ) throws -> Future<[String: Any]> {
+        var results = [String: Future<Any>]()
+
+        fields.forEach { field in
+            results[field.key] = exeContext.eventLoopGroup.next().makeSucceededFuture(true).map { $0 ?? Map.null }
+        }
+
+        var elements: [String: Any] = [:]
+
+        let eventLoopGroup = exeContext.eventLoopGroup
+
+        guard results.count > 0 else {
+            return eventLoopGroup.next().makeSucceededFuture(elements)
+        }
+
+        let promise: EventLoopPromise<[String: Any]> = eventLoopGroup.next().makePromise()
+        elements.reserveCapacity(results.count)
+
+        for (key, value) in results {
+            value.whenSuccess { expectation in
+                elements[key] = expectation
+                
+                if elements.count == results.count {
+                    promise.succeed(elements)
+                }
+            }
+            
+            value.whenFailure { error in
+                promise.fail(error)
+            }
+        }
+
+        return promise.futureResult
+    }
+}

--- a/Sources/Graphiti/Subscription/AddSubscriptionFieldExecutionStrategy.swift
+++ b/Sources/Graphiti/Subscription/AddSubscriptionFieldExecutionStrategy.swift
@@ -9,6 +9,7 @@ import Foundation
 import GraphQL
 import NIO
 
+// All this does is return success for all fields assuming the query validation succeeded
 struct AddSubscriptionFieldExecutionStrategy: SubscriptionFieldExecutionStrategy {
     
     public init () {}

--- a/Sources/Graphiti/Subscription/Subscription.swift
+++ b/Sources/Graphiti/Subscription/Subscription.swift
@@ -1,0 +1,61 @@
+//
+//  Subscription.swift
+//
+//
+//  Created by Ahmed Farrakha on 12/4/20.
+//
+
+import Foundation
+import GraphQL
+
+public final class Subscription<Resolver, Context>: Component<Resolver, Context> {
+    let fields: [FieldComponent<Resolver, Context>]
+    
+    let isTypeOf: GraphQLIsTypeOf = { source, _, _ in
+        return source is Resolver
+    }
+    
+    override func update(typeProvider: SchemaTypeProvider) throws {
+        typeProvider.subscription = try GraphQLObjectType(
+            name: name,
+            description: description,
+            fields: fields(typeProvider: typeProvider),
+            isTypeOf: isTypeOf
+        )
+    }
+
+    func fields(typeProvider: TypeProvider) throws -> GraphQLFieldMap {
+        var map: GraphQLFieldMap = [:]
+        
+        for field in fields {
+            let (name, field) = try field.field(typeProvider: typeProvider)
+            map[name] = field
+        }
+        
+        return map
+    }
+    
+    public init(
+        name: String,
+        fields: [FieldComponent<Resolver, Context>]
+    ) {
+        self.fields = fields
+        super.init(name: name)
+    }
+}
+
+public extension Subscription {
+    convenience init(
+        as name: String = "Subscription",
+        @FieldComponentBuilder<Resolver, Context> _ fields: () -> FieldComponent<Resolver, Context>
+    ) {
+        self.init(name: name, fields: [fields()])
+    }
+    
+    convenience init(
+        as name: String = "Subscription",
+        @FieldComponentBuilder<Resolver, Context> _ fields: () -> [FieldComponent<Resolver, Context>]
+    ) {
+        self.init(name: name, fields: fields())
+    }
+}

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
@@ -370,6 +370,37 @@ class HelloWorldTests : XCTestCase {
         
         wait(for: [expectation], timeout: 10)
     }
+    
+    func testAddSubscription() throws {
+        let subscription = """
+        subscription UserChanged($input: UserChangedInput!) {
+            UserChanged(input: $input) {
+                id
+            }
+        }
+        """
+        
+        let variables: [String: Map] = ["input" : [ "id" : "123"]]
+        
+        let expected = GraphQLResult(
+            data: ["UserChanged" : true]
+        )
+        
+        let expectation = XCTestExpectation()
+        
+        api.execute(
+            request: subscription,
+            context: api.context,
+            on: group,
+            variables: variables,
+            addingSubscription: true
+        ).whenSuccess { result in
+            XCTAssertEqual(result, expected)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 10)
+    }
 }
 
 extension HelloWorldTests {


### PR DESCRIPTION
Add an option to the API execute method to support enabling/disabling add subscription mode. 

If `addSubscription = true` is passed(when registering the subscription), the `AddSubscriptionExecutionStrategy` is used which doesn't try to resolve the fields, just returns success after query validation. If `addSubscription = true`(when we are trying to resolve the actual requested fields when sending an update) is not passed, the default strategy is used which resolves the fields of the request.

A bit hacky but should be good for now.